### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-05-17
+
 ### Added
 
-- Export `AttributeObserver` and `ElementObserver`
-- Support number values with underscores
-- Add `lazyImport` function which imports the elements/targets lazily
+- Export `AttributeObserver` and `ElementObserver` ([#26](https://github.com/Ambiki/impulse/pull/26))
+- Support number values with underscores ([#25](https://github.com/Ambiki/impulse/pull/25))
+- Add `lazyImport` function which imports the elements/targets lazily ([#22](https://github.com/Ambiki/impulse/pull/22))
 
 ### Changed
 
-- Invoke `disconnected` callback before [target]Disconnected callbacks
+- Invoke `disconnected` callback before [target]Disconnected callbacks ([#23](https://github.com/Ambiki/impulse/pull/23))
 
 ## [0.3.0] - 2024-03-17
 
@@ -57,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Everything!
 
-[unreleased]: https://github.com/Ambiki/impulse/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/Ambiki/impulse/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Ambiki/impulse/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Ambiki/impulse/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Ambiki/impulse/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/Ambiki/impulse/compare/v0.1.2...v0.1.3

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ambiki/impulse",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A JavaScript framework that leverages the Web Components API.",
   "author": "Ambitious Idea Labs <info@ambiki.com> (https://ambiki.com/)",
   "contributors": [

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@ambiki/impulse": "0.3.0",
+    "@ambiki/impulse": "0.4.0",
     "vite": "^4.5.3"
   }
 }


### PR DESCRIPTION
### Added

- Export `AttributeObserver` and `ElementObserver` ([#26](https://github.com/Ambiki/impulse/pull/26))
- Support number values with underscores ([#25](https://github.com/Ambiki/impulse/pull/25))
- Add `lazyImport` function which imports the elements/targets lazily ([#22](https://github.com/Ambiki/impulse/pull/22))

### Changed

- Invoke `disconnected` callback before [target]Disconnected callbacks ([#23](https://github.com/Ambiki/impulse/pull/23))

