### PR TITLE
fix: target initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set muliple targets as `[]` and single target as `null` if they cannot be found
+
 ## [0.5.0-beta.2] - 2024-08-26
 
 ### Added
@@ -15,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Optmize event listeners so that only the added/removed actions are processed ([#41](https://github.com/Ambiki/impulse/pull/41))
+- Optimize event listeners so that only the added/removed actions are processed ([#41](https://github.com/Ambiki/impulse/pull/41))
 
 ### Fixed
 

--- a/packages/core/src/decorators/target.ts
+++ b/packages/core/src/decorators/target.ts
@@ -8,7 +8,6 @@ export type TargetType = {
 export function target() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (ctor: any, key: string) => {
-    Object.defineProperty(Object.getPrototypeOf(ctor), key, { configurable: true, value: null });
     const store = new Store(ctor, 'target');
     store.add({ key, multiple: false });
   };
@@ -17,7 +16,6 @@ export function target() {
 export function targets() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (ctor: any, key: string) => {
-    Object.defineProperty(Object.getPrototypeOf(ctor), key, { configurable: true, value: [] });
     const store = new Store(ctor, 'target');
     store.add({ key, multiple: true });
   };

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -20,6 +20,13 @@ export default class Target implements TokenListObserverDelegate {
   }
 
   start() {
+    // Initialize targets with an empty array if it references multiple targets, or with null if it references a single
+    // target. Later, if we find matching targets, we set them accordingly. If we don't, we can still iterate over
+    // targets because it is an array.
+    for (const key of this.keys) {
+      this.defineProperty(key, this.isKeyMultiple(key) ? [] : null);
+    }
+
     if (!this.tokenListObserver) {
       this.tokenListObserver = new TokenListObserver(this.instance, 'data-target', this);
       this.tokenListObserver.start();


### PR DESCRIPTION
Set muliple targets as `[]` and single target as `null` if they cannot be found.