### PR TITLE
v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-02-07
+
 ### Fixed
 
-- Wait for `document.readyState` to be `interactive` before initializing Impulse
+- Wait for `document.readyState` to be `interactive` before initializing Impulse ([#49](https://github.com/Ambiki/impulse/pull/49))
 
 ## [1.0.0] - 2024-11-28
 
@@ -90,7 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Everything!
 
-[unreleased]: https://github.com/Ambiki/impulse/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/Ambiki/impulse/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/Ambiki/impulse/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Ambiki/impulse/compare/v0.5.0-beta.1...v1.0.0
 [0.5.0-beta.2]: https://github.com/Ambiki/impulse/compare/v0.5.0-beta.1...v0.5.0-beta.2
 [0.5.0-beta.1]: https://github.com/Ambiki/impulse/compare/v0.4.0...v0.5.0-beta.1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ambiki/impulse",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A JavaScript framework that leverages the Web Components API.",
   "author": "Ambitious Idea Labs <info@ambiki.com> (https://ambiki.com/)",
   "contributors": [

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@ambiki/impulse": "1.0.0",
+    "@ambiki/impulse": "1.0.1",
     "vite": "^4.5.3"
   }
 }


### PR DESCRIPTION
### Fixed

- Wait for `document.readyState` to be `interactive` before initializing Impulse ([#49](https://github.com/Ambiki/impulse/pull/49))
