### PR TITLE
fix: prevent early invocation of `connected` and `disconnected`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent early invocation of `connected` and `disconnected` functions
+
 ## [1.0.1] - 2025-02-07
 
 ### Fixed

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -12,20 +12,10 @@ export default class ImpulseElement extends HTMLElement {
   private action = new Action(this);
   private _started = false;
 
-  async connectedCallback() {
-    await domReady();
-    customElements.upgrade(this);
-    // Order is important
-    this.property.start();
-    // Resolve all undefined elements before initializing the target/targets so that property references can be resolved
-    // to the assigned value.
-    await this._resolveUndefinedElements();
-    this.target.start();
-    this.action.start();
-    this._started = true;
-
-    this.setAttribute('data-impulse-element', '');
-    this.connected();
+  connectedCallback() {
+    if (!this._started) {
+      this._asyncConnect();
+    }
   }
 
   static get observedAttributes(): string[] {
@@ -59,12 +49,14 @@ export default class ImpulseElement extends HTMLElement {
   }
 
   disconnectedCallback() {
-    // Order is important
-    this.disconnected();
-    this.action.stop();
-    this.target.stop();
-    this.property.stop();
-    this._started = false;
+    if (this._started) {
+      // Order is important
+      this.disconnected();
+      this.action.stop();
+      this.target.stop();
+      this.property.stop();
+      this._started = false;
+    }
   }
 
   connected() {
@@ -95,6 +87,22 @@ export default class ImpulseElement extends HTMLElement {
 
   get identifier() {
     return this.tagName.toLowerCase();
+  }
+
+  private async _asyncConnect() {
+    await domReady();
+    customElements.upgrade(this);
+    // Order is important
+    this.property.start();
+    // Resolve all undefined elements before initializing the target/targets so that property references can be resolved
+    // to the assigned value.
+    await this._resolveUndefinedElements();
+    this.target.start();
+    this.action.start();
+    this._started = true;
+
+    this.setAttribute('data-impulse-element', '');
+    this.connected();
   }
 
   private _resolveUndefinedElements() {


### PR DESCRIPTION
functions