### PR TITLE
feat: lifecycle functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `onConnected` and `onDisconnected` lifecycle functions
+
 ## [1.0.2] - 2025-06-15
 
 ### Fixed

--- a/packages/core/src/helpers/dom.ts
+++ b/packages/core/src/helpers/dom.ts
@@ -10,3 +10,24 @@ export function domReady() {
     }
   });
 }
+
+/**
+ * Returns all descendant elements matching the selector, including the root element if it matches.
+ *
+ * @param element - The root element to search from
+ * @param selector - CSS selector to match against
+ * @returns Array of matching elements, with the root element first if it matches the selector
+ *
+ * @example
+ * ```ts
+ * const container = document.querySelector('.container');
+ * const buttons = getMatchingElementsFrom(container, 'button');
+ * ```
+ */
+export function getMatchingElementsFrom(element: Element, selector: string) {
+  const elements = Array.from(element.querySelectorAll(selector));
+  if (element.matches(selector)) {
+    elements.unshift(element);
+  }
+  return elements;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export { default as registerElement } from './decorators/register_element';
 export * from './decorators/target';
 export { default as ImpulseElement } from './element';
 export { default as lazyImport } from './lazy_import';
+export * from './lifecycle';
 export * from './observers/attribute_observer';
 export * from './observers/element_observer';
 export * from './observers/token_list_observer';

--- a/packages/core/src/lazy_import.ts
+++ b/packages/core/src/lazy_import.ts
@@ -1,5 +1,5 @@
 import SetMap from './data_structures/set_map';
-import { domReady } from './helpers/dom';
+import { domReady, getMatchingElementsFrom } from './helpers/dom';
 import { ElementObserver } from './observers/element_observer';
 
 const lazyElements = new SetMap<string, () => void>();
@@ -30,11 +30,7 @@ export default function lazyImport(selector: string, callback: () => void) {
       }
     },
     getMatchingElements(element) {
-      const elements = Array.from(element.querySelectorAll(selector));
-      if (element.matches(selector)) {
-        elements.unshift(element);
-      }
-      return elements;
+      return getMatchingElementsFrom(element, selector);
     },
   });
 

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -1,0 +1,58 @@
+import { getMatchingElementsFrom } from './helpers/dom';
+import { ElementObserver, type ElementObserverDelegate } from './observers/element_observer';
+
+export interface OnConnectedOptions extends MutationObserverInit {}
+
+/**
+ * Observes the DOM and invokes a callback whenever elements matching the selector are added to the DOM.
+ *
+ * This function sets up a MutationObserver on the document that watches for elements matching
+ * the provided CSS selector. The callback is invoked immediately for any matching elements
+ * already in the DOM, and then for any elements added later.
+ *
+ * @param selector - CSS selector to match elements against
+ * @param callback - Function to invoke when a matching element is mounted. Can optionally return
+ *                   a cleanup function that will be called when the element is disconnected.
+ * @param options - Optional configuration
+ *
+ * @example
+ * ```ts
+ * // Watch for all buttons being added to the DOM
+ * onConnected('button', (element) => {
+ *   console.log('Button mounted: ', element);
+ * });
+ *
+ * // With cleanup function
+ * onConnected('.dynamic-content', (element) => {
+ *   console.log('Element connected: ', element);
+ *   return () => {
+ *     console.log('Element disconnected: ', element);
+ *   };
+ * });
+ *
+ * // With custom observer options
+ * onConnected('.widget', (element) => {
+ *   initializeWidget(element);
+ * }, { attributes: false });
+ * ```
+ */
+export function onConnected(
+  selector: string,
+  callback: (element: Element) => void | (() => void),
+  options: OnConnectedOptions = {}
+) {
+  let cleanup: void | (() => void);
+  const delegate: ElementObserverDelegate = {
+    elementConnected: (element) => {
+      cleanup = callback(element);
+    },
+    elementDisconnected: () => {
+      if (cleanup) {
+        cleanup();
+      }
+    },
+    getMatchingElements: (element) => getMatchingElementsFrom(element, selector),
+  };
+  const observer = new ElementObserver(document.documentElement, delegate, { attributes: true, ...options });
+  observer.start();
+}

--- a/packages/core/test/lifecycle.test.ts
+++ b/packages/core/test/lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { expect, fixture, html, nextFrame } from '@open-wc/testing';
 import Sinon from 'sinon';
 import { onConnected } from '../src';
+import { onDisconnected } from '../dist';
 
 describe('onConnected', () => {
   it('invokes when element is already present', async () => {
@@ -73,5 +74,50 @@ describe('onConnected', () => {
     root.remove();
     await nextFrame();
     expect(disconnected.calledOnceWith(root)).to.be.true;
+  });
+});
+
+describe('onDisconnected', () => {
+  it('invokes when element is removed', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div class="selector"></div>`);
+    onDisconnected('.selector', callback);
+
+    await nextFrame();
+    expect(callback.called).to.be.false;
+
+    root.remove();
+    await nextFrame();
+    expect(callback.calledOnceWith(root)).to.be.true;
+  });
+
+  it('invokes when the selector value is removed', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div class="selector"></div>`);
+    onDisconnected('.selector', callback);
+
+    root.setAttribute('class', '');
+    await nextFrame();
+    expect(callback.calledOnceWith(root)).to.be.true;
+  });
+
+  it('invokes when the selector itself is removed', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div class="selector"></div>`);
+    onDisconnected('.selector', callback);
+
+    root.removeAttribute('class');
+    await nextFrame();
+    expect(callback.calledOnceWith(root)).to.be.true;
+  });
+
+  it('does not invoke if the selector is removed', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div class="selector"></div>`);
+    onDisconnected('.selector', callback, { attributes: false });
+
+    root.removeAttribute('class');
+    await nextFrame();
+    expect(callback.calledOnceWith(root)).to.be.false;
   });
 });

--- a/packages/core/test/lifecycle.test.ts
+++ b/packages/core/test/lifecycle.test.ts
@@ -1,0 +1,77 @@
+import { expect, fixture, html, nextFrame } from '@open-wc/testing';
+import Sinon from 'sinon';
+import { onConnected } from '../src';
+
+describe('onConnected', () => {
+  it('invokes when element is already present', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div class="selector"></div>`);
+    onConnected('.selector', callback);
+
+    await nextFrame();
+    expect(callback.calledOnceWith(root)).to.be.true;
+  });
+
+  it('invokes when element is added', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div></div>`);
+    onConnected('#selector', callback);
+
+    const element = document.createElement('div');
+    element.setAttribute('id', 'selector');
+    root.append(element);
+    await nextFrame();
+    expect(callback.calledOnceWith(element)).to.be.true;
+  });
+
+  it('invokes when the selector is added', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div></div>`);
+    onConnected('.selector', callback);
+
+    root.setAttribute('class', 'selector');
+    await nextFrame();
+    expect(callback.calledOnceWith(root)).to.be.true;
+  });
+
+  it('does not invoke when the selector is added', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div></div>`);
+    onConnected('.selector', callback, { attributes: false });
+
+    root.setAttribute('class', 'selector');
+    await nextFrame();
+    expect(callback.called).to.be.false;
+  });
+
+  it('does not invoke if element does not match the selector', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div></div>`);
+    onConnected('#selector', callback);
+
+    const element = document.createElement('div');
+    element.setAttribute('id', 'input');
+    root.append(element);
+    await nextFrame();
+    expect(callback.called).to.be.false;
+  });
+
+  it('invokes the return function when element is removed', async () => {
+    const connected = Sinon.spy();
+    const disconnected = Sinon.spy();
+    const root = await fixture(html`<div class="selector"></div>`);
+    onConnected('.selector', (element) => {
+      connected(element);
+      return () => {
+        disconnected(element);
+      };
+    });
+
+    await nextFrame();
+    expect(connected.calledOnceWith(root)).to.be.true;
+
+    root.remove();
+    await nextFrame();
+    expect(disconnected.calledOnceWith(root)).to.be.true;
+  });
+});


### PR DESCRIPTION
This PR adds two lifecycle functions:
1. `onConnected` -> called when the element is added to the DOM
2. `onDisconnected` -> called when the element is removed from the DOM

Sometimes it isn’t feasible to write Impulse components, and the goal of this PR is to make it easier for Ambiki teammates to write maintainable, fault-tolerant JavaScript. You no longer have to worry about Turbolinks/Turbo - it just works.

## Usage

### `onConnected`

```ts
import { onConnected } from '@ambiki/impulse';

onConnected('.my-button', (element) => {
  console.log('Button added to the DOM: ', element);
  
  // Optional return function that gets called when the button
  // is removed from the DOM.
  return () => {
    console.log('Button removed from the DOM: ', element);
  }
});
```

### `onDisconnected`

```ts
import { onDisconnected } from '@ambiki/impulse';

onDisconnected('.my-button', (element) => {
  console.log('Button removed from the DOM: ', element);
});
```