### PR TITLE
feat: add `on` and `emit` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `on` and `emit` event functions
 - Add `onConnected` and `onDisconnected` lifecycle functions
 
 ## [1.0.2] - 2025-06-15

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -1,5 +1,6 @@
 import Action from './action';
 import type { PropertyConstructor, PropertyType } from './decorators/property';
+import { emit } from './events';
 import { domReady } from './helpers/dom';
 import { camelize, dasherize, parseJSON } from './helpers/string';
 import Property from './property';
@@ -75,14 +76,11 @@ export default class ImpulseElement extends HTMLElement {
     {
       target = this,
       prefix = this.identifier,
-      detail = {} as T,
       ...rest
     }: CustomEventInit<T> & { target?: Element | Window | Document; prefix?: boolean | string } = {}
   ): CustomEvent<T> {
     const eventName = prefix ? `${prefix}:${name}` : name;
-    const event = new CustomEvent(eventName, { bubbles: true, composed: true, detail, ...rest });
-    target.dispatchEvent(event);
-    return event;
+    return emit(target, eventName, rest);
   }
 
   get identifier() {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,0 +1,133 @@
+import { onConnected } from './lifecycle';
+
+/**
+ * Sets up an event listener that automatically attaches to elements matching the selector.
+ *
+ * This function observes the DOM and automatically adds event listeners to elements matching
+ * the provided CSS selector. Event listeners are added to existing elements immediately and
+ * to new elements as they're added to the DOM. When elements are removed or no longer match
+ * the selector, their event listeners are automatically cleaned up.
+ *
+ * @param eventName - The name of the event to listen for (e.g., 'click', 'focus', 'custom-event')
+ * @param selector - CSS selector to match elements against
+ * @param callback - Function to invoke when the event occurs. Receives the event and matching element.
+ * @param options - Optional event listener options (capture, once, passive, etc.)
+ * @returns A cleanup function that removes all event listeners and stops observing
+ *
+ * @example
+ * ```ts
+ * // Listen for clicks on all buttons with inferred types
+ * on('click', 'button', (event, element) => {
+ *   console.log('Button clicked:', element);
+ * });
+ *
+ * // Use event listener options
+ * on('click', '.once-button', (event, element) => {
+ *   console.log('Clicked once');
+ * }, { once: true });
+ *
+ * // Manual cleanup
+ * const stop = on('click', 'button', (event, element) => {
+ *   console.log('Clicked');
+ * });
+ * stop();
+ * ```
+ */
+// Tag name selector with inferred event type: on('click', 'button', ...)
+export function on<K extends keyof HTMLElementTagNameMap, E extends keyof HTMLElementEventMap>(
+  eventName: E,
+  selector: K,
+  callback: (event: HTMLElementEventMap[E], element: HTMLElementTagNameMap[K]) => void,
+  options?: boolean | AddEventListenerOptions
+): () => void;
+// Tag name selector with custom event type: on<CustomEvent, 'form'>('ajax', 'form', ...)
+export function on<Ev extends Event, K extends keyof HTMLElementTagNameMap>(
+  eventName: string,
+  selector: K,
+  callback: (event: Ev, element: HTMLElementTagNameMap[K]) => void,
+  options?: boolean | AddEventListenerOptions
+): () => void;
+// Element type with native event: on<HTMLButtonElement>('click', '.btn', ...) - event inferred from eventName
+export function on<T extends HTMLElement>(
+  eventName: keyof HTMLElementEventMap,
+  selector: string,
+  callback: (event: Event, element: T) => void,
+  options?: boolean | AddEventListenerOptions
+): () => void;
+// Custom selector with native event and element type: on<'click', HTMLButtonElement>('click', '.btn', ...)
+export function on<E extends keyof HTMLElementEventMap, T extends Element = Element>(
+  eventName: E,
+  selector: string,
+  callback: (event: HTMLElementEventMap[E], element: T) => void,
+  options?: boolean | AddEventListenerOptions
+): () => void;
+// Custom selector with custom event type: on<CustomEvent>('ajax', '.form', ...)
+export function on<Ev extends Event, T extends Element = Element>(
+  eventName: string,
+  selector: string,
+  callback: (event: Ev, element: T) => void,
+  options?: boolean | AddEventListenerOptions
+): () => void;
+export function on(
+  eventName: string,
+  selector: string,
+  callback: (event: Event, element: Element) => void,
+  options?: boolean | AddEventListenerOptions
+): () => void {
+  return onConnected(selector, (element) => {
+    const handler = (event: Event) => callback(event, element);
+    element.addEventListener(eventName, handler, options);
+    return () => {
+      element.removeEventListener(eventName, handler, options);
+    };
+  });
+}
+
+/**
+ * Dispatches a custom event from the specified target element.
+ *
+ * This is a convenience function for creating and dispatching CustomEvents with typed detail data.
+ * Events are created with `bubbles: true` and `composed: true` by default, allowing them to
+ * propagate through the DOM and cross shadow DOM boundaries.
+ *
+ * @param target - The element, window, or document to dispatch the event from
+ * @param eventName - The name of the custom event
+ * @param options - CustomEvent options including detail data and event configuration
+ * @returns The CustomEvent that was dispatched
+ *
+ * @example
+ * ```ts
+ * // Dispatch a simple custom event
+ * const button = document.querySelector('button');
+ * emit(button, 'custom-click', { detail: { count: 1 } });
+ *
+ * // Dispatch with typed detail data
+ * interface FormData {
+ *   username: string;
+ *   email: string;
+ * }
+ * const form = document.querySelector('form');
+ * emit<FormData>(form, 'form-submit', {
+ *   detail: { username: 'john', email: 'john@example.com' }
+ * });
+ *
+ * // Dispatch without bubbling
+ * emit(element, 'local-event', {
+ *   detail: { message: 'Hello' },
+ *   bubbles: false
+ * });
+ *
+ * // Dispatch and access the event object
+ * const event = emit(element, 'my-event', { detail: { success: true } });
+ * console.log(event.defaultPrevented);
+ * ```
+ */
+export function emit<T extends Record<string, any>>(
+  target: Element | Window | Document,
+  eventName: string,
+  { detail = {} as T, ...rest }: CustomEventInit<T> = {}
+) {
+  const event = new CustomEvent(eventName, { bubbles: true, composed: true, detail, ...rest });
+  target.dispatchEvent(event);
+  return event;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export * from './decorators/target';
 export { default as ImpulseElement } from './element';
 export { default as lazyImport } from './lazy_import';
 export * from './lifecycle';
+export * from './events';
 export * from './observers/attribute_observer';
 export * from './observers/element_observer';
 export * from './observers/token_list_observer';

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -14,6 +14,7 @@ export interface OnConnectedOptions extends Omit<MutationObserverInit, 'childLis
  * @param callback - Function to invoke when a matching element is mounted. Can optionally return
  *                   a cleanup function that will be called when the element is disconnected.
  * @param options - Optional configuration
+ * @returns A cleanup function that stops observing
  *
  * @example
  * ```ts
@@ -92,6 +93,7 @@ interface OnDisconnectedOptions extends Omit<MutationObserverInit, 'childList' |
  * @param selector - CSS selector to match elements against
  * @param callback - Function to invoke when a matching element is disconnected
  * @param options - Optional configuration
+ * @returns A cleanup function that stops observing
  *
  * @example
  * ```ts

--- a/packages/core/test/events.test.ts
+++ b/packages/core/test/events.test.ts
@@ -1,0 +1,76 @@
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import Sinon from 'sinon';
+import { emit, on } from '../src';
+
+describe('on', () => {
+  it('sets up an event listener', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture<HTMLButtonElement>(html`<button></button>`);
+    on('click', 'button', callback);
+
+    root.click();
+    expect(callback.calledOnce).to.be.true;
+    expect(callback.firstCall.args[0]).to.be.instanceOf(Event);
+    expect(callback.firstCall.args[1]).to.eq(root);
+  });
+
+  it('cleans up the event listener manually', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture<HTMLButtonElement>(html`<button id="selector"></button>`);
+    const stop = on('click', '#selector', callback);
+
+    root.click();
+    expect(callback.calledOnce).to.be.true;
+
+    callback.resetHistory();
+    stop();
+    expect(callback.called).to.be.false;
+  });
+
+  it('cleans up the event listener when attribute itself is removed', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture<HTMLButtonElement>(html`<button id="selector"></button>`);
+    on('click', '#selector', callback);
+
+    root.click();
+    expect(callback.calledOnce).to.be.true;
+
+    callback.resetHistory();
+    root.removeAttribute('id');
+    await waitUntil(() => !root.hasAttribute('id'));
+    root.click();
+    expect(callback.called).to.be.false;
+  });
+
+  it('supports event listener options', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture<HTMLButtonElement>(html`<button id="selector"></button>`);
+    on('click', '#selector', callback, { once: true });
+
+    root.click();
+    root.click();
+    expect(callback.callCount).to.eq(1);
+  });
+});
+
+describe('emit', () => {
+  it('emits an event', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div></div>`);
+    document.addEventListener('emit-test:change', callback);
+
+    emit(root, 'emit-test:change');
+    expect(callback.calledOnce).to.be.true;
+    expect(callback.getCall(0).args[0].detail).to.deep.equal({});
+  });
+
+  it('sets the detail', async () => {
+    const callback = Sinon.spy();
+    const root = await fixture(html`<div></div>`);
+    document.addEventListener('emit-test:change', callback);
+
+    emit<{ name: string }>(root, 'emit-test:change', { detail: { name: 'John' } });
+    expect(callback.calledOnce).to.be.true;
+    expect(callback.getCall(0).args[0].detail).to.deep.equal({ name: 'John' });
+  });
+});

--- a/packages/docs/reference/targets.md
+++ b/packages/docs/reference/targets.md
@@ -38,7 +38,7 @@ A single target can be referenced via the `@target()` decorator. It is a syntact
 
 ```ts{6}
 // elements/greet_user_element.ts
-import { ImpulseElement, registerElement, target } from 'impulse';
+import { ImpulseElement, registerElement, target } from '@ambiki/impulse';
 
 @registerElement('greet-user')
 export default class GreetUserElement extends ImpulseElement {
@@ -52,7 +52,6 @@ export default class GreetUserElement extends ImpulseElement {
 
 Multiple targets can be referenced via the `@targets()` decorator. It is a syntactic sugar for `Array.from(this.querySelectorAll('...'))`.
 
-
 ```html{2,3}
 <greet-user>
   <div data-target="greet-user.results"></div>
@@ -62,7 +61,7 @@ Multiple targets can be referenced via the `@targets()` decorator. It is a synta
 
 ```ts{6}
 // elements/greet_user_element.ts
-import { ImpulseElement, registerElement, targets } from 'impulse';
+import { ImpulseElement, registerElement, targets } from '@ambiki/impulse';
 
 @registerElement('greet-user')
 export default class GreetUserElement extends ImpulseElement {
@@ -81,7 +80,7 @@ Define a `[target]Connected` or `[target]Disconnected` function, where `[target]
 observe. The function receives the element as the first argument.
 
 ```ts{5,7,11}
-import { ImpulseElement, registerElement, target } from 'impulse';
+import { ImpulseElement, registerElement, target } from '@ambiki/impulse';
 
 @registerElement('greet-user')
 export default class GreetUserElement extends ImpulseElement {
@@ -107,7 +106,7 @@ Always use camelCase to reference the target in your HTML.
 ```
 
 ```ts
-import { ImpulseElement, registerElement, target } from 'impulse';
+import { ImpulseElement, registerElement, target } from '@ambiki/impulse';
 
 @registerElement('greet-user')
 export default class GreetUserElement extends ImpulseElement {


### PR DESCRIPTION
Add two new utility functions for simplified DOM event management:

- `on()`: Automatically attaches event listeners to elements matching a CSS selector, with automatic cleanup when elements are removed or no longer match. Supports both native and custom events with full TypeScript type inference.

- `emit()`: Convenience function for dispatching CustomEvents with typed detail data. Events bubble and compose by default.