### PR TITLE
test: guard `_resolveUndefinedElements` ordering behavior

### DIFF
--- a/packages/core/test/element.test.ts
+++ b/packages/core/test/element.test.ts
@@ -1,0 +1,48 @@
+import { expect, waitUntil } from '@open-wc/testing';
+import { ImpulseElement, property, registerElement, target } from '../src';
+
+let counter = 0;
+
+describe('ImpulseElement connection order', () => {
+  it('waits for descendant custom elements to be defined before invoking targetConnected', async () => {
+    counter += 1;
+    const parentTag = `awaiter-parent-${counter}`;
+    const childTag = `awaited-child-${counter}`;
+
+    class Child extends ImpulseElement {
+      @property({ type: String }) message = 'default';
+    }
+
+    class Parent extends ImpulseElement {
+      @target() child!: Child;
+      capturedMessage = '<unset>';
+      childConnected(child: Child) {
+        this.capturedMessage = child.message;
+      }
+    }
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+      <${parentTag}>
+        <${childTag} message="from-attribute" data-target="${parentTag}.child"></${childTag}>
+      </${parentTag}>
+    `;
+
+    registerElement(parentTag)(Parent);
+    document.body.appendChild(wrapper);
+
+    // Yield so the parent's `_asyncConnect` has a chance to suspend at
+    // `_resolveUndefinedElements()` before we register the child class.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    registerElement(childTag)(Child);
+
+    try {
+      const parent = wrapper.firstElementChild as Parent;
+      await waitUntil(() => parent.capturedMessage !== '<unset>', 'childConnected should fire', { timeout: 200 });
+      expect(parent.capturedMessage).to.eq('from-attribute');
+    } finally {
+      wrapper.remove();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a spec that codifies the behavior `_resolveUndefinedElements` currently provides: a parent `ImpulseElement` waits for any undefined descendant custom elements to be defined before invoking `targetConnected`, so that `@property` accessors on the target are installed by the time the parent reads them.
- The spec passes today and **fails** if the `await this._resolveUndefinedElements()` call in `element.ts` is removed - making the behavior change visible before we drop the wait in a follow-up PR.

## Why

Setup work for removing `_resolveUndefinedElements`. Per the HTML spec, parents should be upgraded before their descendants, but `_resolveUndefinedElements` inverts this by parking the parent's `_asyncConnect` until every undefined descendant resolves - and if a descendant is *never* defined, the parent's `connected()` never fires. Removing the wait is a breaking behavior change; this PR locks in the current contract first so the follow-up's diff is self-explanatory.

## Test plan

- [x] `yarn test` - new spec passes (125/125)
- [x] Verified the spec fails with `await this._resolveUndefinedElements()` commented out

🤖 Generated with [Claude Code](https://claude.com/claude-code)