### PR TITLE
Fix for Useless assignment to property

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -1,9 +1,7 @@
 import type { ImpulseElement } from './element';
 
 export default class Scope {
-  constructor(private readonly instance: ImpulseElement) {
-    this.instance = instance;
-  }
+  constructor(private readonly instance: ImpulseElement) {}
 
   findTarget(selector: string): Element | null {
     return this.instance.matches(selector) ? this.instance : this.getElements(selector).find(this.scopedTarget) || null;


### PR DESCRIPTION
To fix this cleanly without changing functionality, remove the redundant assignment inside the constructor body and keep the parameter property as the single source of initialization.

In `packages/core/src/scope.ts`, edit the constructor so it no longer assigns `this.instance = instance;`. Keep `constructor(private readonly instance: ImpulseElement)` unchanged. No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._