### PR TITLE
Fix for Useless assignment to property

### DIFF
--- a/packages/core/src/property.ts
+++ b/packages/core/src/property.ts
@@ -7,7 +7,6 @@ export default class Property {
   private store: Store<PropertyType>;
 
   constructor(private readonly instance: ImpulseElement) {
-    this.instance = instance;
     this.store = new Store<PropertyType>(Object.getPrototypeOf(this.instance), 'property');
   }
 


### PR DESCRIPTION
The fix is to remove the redundant explicit assignment in the constructor.

Best single fix without changing functionality:
- In `packages/core/src/property.ts`, inside `Property` constructor, delete `this.instance = instance;` (line 10 in the snippet).
- Keep the constructor parameter property (`private readonly instance: ImpulseElement`) as-is, since that is the correct initialization mechanism.
- No imports, new methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._