### PR TITLE
Fix for Useless assignment to property

### DIFF
--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -14,7 +14,6 @@ export default class Target<T extends Element> implements TokenListWatcherDelega
   private stopWatching?: () => void;
 
   constructor(private readonly instance: ImpulseElement) {
-    this.instance = instance;
     this.store = new Store<TargetType>(Object.getPrototypeOf(this.instance), 'target');
     this.scope = new Scope(this.instance);
     this.targetsByKey = new SetMap();


### PR DESCRIPTION
Remove the redundant explicit assignment `this.instance = instance;` from the constructor in `packages/core/src/target.ts`.

- General fix: when using a TypeScript parameter property (e.g., `private readonly instance` in constructor parameters), do not manually assign that same property in the constructor body.
- Best concrete fix here: delete line 17 only, leaving the parameter property intact and all other initialization unchanged.
- File/region: `packages/core/src/target.ts`, constructor of `Target` class (lines 16–21 in the provided snippet).
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._