### PR TITLE
Remove `data-impulse-element` attribute on disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Preserve DOM order for `@targets()` when a target is dynamically inserted between existing targets
+- Remove the `data-impulse-element` attribute when an element is disconnected so mutation observers tracking it stay in sync with the DOM connection state ([#110](https://github.com/Ambiki/impulse/issues/110))
 
 ## [1.1.0] - 2025-10-25
 

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -57,6 +57,7 @@ export class ImpulseElement extends HTMLElement {
       this.target.stop();
       this.property.stop();
       this._started = false;
+      this.removeAttribute('data-impulse-element');
     }
   }
 

--- a/packages/core/test/element.test.ts
+++ b/packages/core/test/element.test.ts
@@ -46,4 +46,28 @@ describe('ImpulseElement connection order', () => {
       wrapper.remove();
     }
   });
+
+  it('adds the data-impulse-element attribute on connect and removes it on disconnect', async () => {
+    counter += 1;
+    const tag = `marker-element-${counter}`;
+
+    class Element extends ImpulseElement {}
+
+    registerElement(tag)(Element);
+
+    const element = document.createElement(tag) as Element;
+    document.body.appendChild(element);
+
+    try {
+      await waitUntil(() => element.hasAttribute('data-impulse-element'), 'attribute should be added on connect', {
+        timeout: CONNECTION_TIMEOUT_MS,
+      });
+      expect(element.hasAttribute('data-impulse-element')).to.be.true;
+
+      element.remove();
+      expect(element.hasAttribute('data-impulse-element')).to.be.false;
+    } finally {
+      element.remove();
+    }
+  });
 });


### PR DESCRIPTION
## Description

`ImpulseElement` sets a `data-impulse-element` marker attribute on itself when it finishes connecting (`_asyncConnect`), but it was never removed when the element left the DOM. End users watch this attribute with a `MutationObserver` to know when an Impulse element is live; because the attribute lingered after `disconnectedCallback()`, observers fired unexpectedly and dependent promises did not resolve in sync with the actual DOM connection state.

## Change

- `packages/core/src/element.ts`: remove `data-impulse-element` in `disconnectedCallback()`, mirroring the `setAttribute` in `_asyncConnect()`. Placed inside the existing `if (this._started)` block so it only runs for elements that actually finished connecting.
- `packages/core/test/element.test.ts`: new test asserting the attribute is present after connect and gone after `remove()`.
- `CHANGELOG.md`: entry under Unreleased → Fixed.

Verified red→green: with the fix commented out the new test fails (`expected true to be false`); restored, all 126 core tests pass.

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)