### PR TITLE
build: add ES2018.Promise lib for Promise.finally

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["ES2017", "ES2022.Object", "dom", "dom.iterable"],
+    "lib": ["ES2017", "ES2018.Promise", "ES2022.Object", "dom", "dom.iterable"],
     "useDefineForClassFields": false,
     "experimentalDecorators": true,
     "module": "ESNext",


### PR DESCRIPTION
## Summary

`src/lifecycle.ts:163` uses `Promise.prototype.finally` (ES2018), but the shared `tsconfig.json` `lib` only listed `ES2017`, so every build emitted:

```
(!) Plugin typescript: @rollup/plugin-typescript TS2550: Property 'finally' does not exist on type 'Promise<...>'.
Try changing the 'lib' compiler option to 'es2018' or later.
```

Added `ES2018.Promise` to the `lib` array. This provides only the type definition; `target` stays `ES2017` because `finally` is a runtime method (not syntax), so nothing needs downleveling and no other ES2018 lib features are pulled in.

## Test plan

- `yarn workspace @ambiki/impulse build` — clean, no TS2550 warning
- `yarn lint` — clean
- `yarn workspace @ambiki/impulse test` — 131/131 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)