### PR TITLE
fix(core): treat NaN as unchanged in Number attribute dedupe

### DIFF
--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -45,7 +45,9 @@ export class ImpulseElement extends HTMLElement {
     // Common case would be:
     // -> 8_000 to 8000
     const { newValue, oldValue } = attributeValueTransformer(_newValue, _oldValue, property.type);
-    if (newValue === oldValue) return;
+    // `Object.is` rather than `===` so a Number that transforms to `NaN` on both sides (e.g. a
+    // non-numeric value replaced with another) is treated as unchanged and does not fire the callback.
+    if (Object.is(newValue, oldValue)) return;
 
     fn.call(this, newValue, oldValue);
   }

--- a/packages/core/test/property.test.ts
+++ b/packages/core/test/property.test.ts
@@ -233,4 +233,16 @@ describe('@property', () => {
     el.numericValue = 9000;
     expect(el.numericValueChanged.calledOnceWith(9000, 8000)).to.be.true;
   });
+
+  it('should not fire the Number callback when the value transforms to NaN on both sides', () => {
+    // Starts from `numeric-value="8_000"` (=> 8000).
+    el.setAttribute('numeric-value', 'abc');
+    expect(el.numericValueChanged.calledOnce).to.be.true;
+    expect(Number.isNaN(el.numericValueChanged.getCall(0).args[0])).to.be.true;
+    expect(el.numericValueChanged.getCall(0).args[1]).to.equal(8000);
+
+    // NaN -> NaN is unchanged, so the callback must not fire again.
+    el.setAttribute('numeric-value', 'xyz');
+    expect(el.numericValueChanged.calledOnce).to.be.true;
+  });
 });


### PR DESCRIPTION
## Summary

`attributeChangedCallback` skips the `[property]Changed` callback when the transformed old/new values are equal, to suppress no-op changes (e.g. `"8_000"` → `"8000"` both become `8000`). It used `===`.

For a `Number` property, any non-numeric value transforms to `NaN`, and `NaN === NaN` is always `false`. So when both sides transform to `NaN` (one non-numeric value replaced with another, or absent → non-numeric), the guard never triggers and a spurious `xChanged(NaN, NaN)` fires.

Switched the guard to `Object.is`, which treats `NaN` as equal to `NaN` while behaving exactly like `===` for every other value.

```ts
el.setAttribute('numeric-value', 'abc');  // 8000 -> NaN: fires (real change)
el.setAttribute('numeric-value', 'xyz');  // NaN -> NaN: previously fired spuriously; now skipped
```

## Test plan

Added a regression test (`test/property.test.ts`) and verified red → green:

- **Reverted to `===`** → new test fails: `expected false to be true` (callback fired twice).
- **With `Object.is`** → 132/132 pass.

Also: `yarn lint` clean, `yarn workspace @ambiki/impulse build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)