### PR TITLE
feat(core): deprecate implicit descendant-definition wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lazyImport` no longer leaks a `MutationObserver` per call: the watcher is now torn down after the first match fires
 - `on` now uses event delegation: a single document-level event listener is shared across every `on(eventName, ...)` call with the same capture phase, dispatching to handlers via the central `SelectorSet` index. Previously each call attached one listener per matching element. `event.currentTarget` is patched to point at the matched ancestor so existing handler code continues to work; `event.stopPropagation()` halts further delegated dispatch on the same event
 
+### Deprecated
+
+- The implicit wait for descendant custom elements to be defined before invoking target connected callbacks is deprecated and will be removed in the next major version. If a connected callback reads properties on a target element, `await whenInitialized(target)` inside the callback instead. Silence the warning after migrating by setting `ImpulseElement.migratedToWhenInitialized = true`
+
 ### Removed (BREAKING)
 
 - Public exports of `SelectorObserver`, `ElementObserver`, `AttributeObserver`, and `TokenListObserver`. Use `connected` / `disconnected` instead. The underlying classes have been removed entirely; `@target` and `@action` now share the central observer via an internal `watchTokenList` helper

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -9,6 +9,13 @@ import Store from './store';
 import Target from './target';
 
 export class ImpulseElement extends HTMLElement {
+  /**
+   * Set to `true` once you have migrated target connected callbacks to `whenInitialized()` to silence the deprecation
+   * warning about the implicit descendant-definition wait. Set it on `ImpulseElement` to opt out globally, or on a
+   * specific element class to opt out per class.
+   */
+  static migratedToWhenInitialized = false;
+
   private property = new Property(this);
   private target = new Target(this);
   private action = new Action(this);
@@ -98,6 +105,8 @@ export class ImpulseElement extends HTMLElement {
     this.property.start();
     // Resolve all undefined elements before initializing the target/targets so that property references can be resolved
     // to the assigned value.
+    // DEPRECATED: this implicit wait will be removed in the next major version. Use `whenInitialized()` inside connected
+    // callbacks instead. See `_resolveUndefinedElements`.
     await this._resolveUndefinedElements();
     this.target.start();
     this.action.start();
@@ -109,6 +118,15 @@ export class ImpulseElement extends HTMLElement {
 
   private _resolveUndefinedElements() {
     const undefinedElements = Array.from(this.querySelectorAll(':not(:defined)'));
+    const migrated = (this.constructor as typeof ImpulseElement).migratedToWhenInitialized;
+    if (undefinedElements.length > 0 && !migrated) {
+      console.warn(
+        `[impulse] <${this.identifier}> waits for descendant custom elements to be defined before invoking target ` +
+        `connected callbacks. This is deprecated and will be removed in the next major version. If a connected ` +
+        `callback reads properties on a target element, await whenInitialized(target) inside the callback instead. ` +
+        `Set ImpulseElement.migratedToWhenInitialized = true to silence this warning.`,
+      );
+    }
     const promises = undefinedElements.map((element) => customElements.whenDefined(element.localName));
     return Promise.all(promises);
   }

--- a/packages/core/test/element.test.ts
+++ b/packages/core/test/element.test.ts
@@ -1,4 +1,5 @@
 import { expect, waitUntil } from '@open-wc/testing';
+import Sinon from 'sinon';
 import { ImpulseElement, property, registerElement, target } from '../src';
 
 let counter = 0;
@@ -43,6 +44,69 @@ describe('ImpulseElement connection order', () => {
       await waitUntil(() => parent.capturedMessage !== '<unset>', 'childConnected should fire', { timeout: CONNECTION_TIMEOUT_MS });
       expect(parent.capturedMessage).to.eq('from-attribute');
     } finally {
+      wrapper.remove();
+    }
+  });
+
+  it('warns that the implicit descendant-definition wait is deprecated', async () => {
+    counter += 1;
+    const parentTag = `deprecation-parent-${counter}`;
+    const childTag = `deprecation-child-${counter}`;
+    const warn = Sinon.stub(console, 'warn');
+
+    class Child extends ImpulseElement {}
+    class Parent extends ImpulseElement {
+      @target() child!: Child;
+    }
+
+    const wrapper = document.createElement('div');
+    // The child class is intentionally never registered, so it stays undefined and the parent engages the wait.
+    wrapper.innerHTML = `
+      <${parentTag}>
+        <${childTag} data-target="${parentTag}.child"></${childTag}>
+      </${parentTag}>
+    `;
+
+    registerElement(parentTag)(Parent);
+    document.body.appendChild(wrapper);
+
+    try {
+      await waitUntil(() => warn.called, 'deprecation warning should be emitted', { timeout: CONNECTION_TIMEOUT_MS });
+      expect(warn.getCall(0).args[0]).to.include('whenInitialized');
+    } finally {
+      warn.restore();
+      wrapper.remove();
+    }
+  });
+
+  it('does not warn when migratedToWhenInitialized is set', async () => {
+    counter += 1;
+    const parentTag = `migrated-parent-${counter}`;
+    const childTag = `migrated-child-${counter}`;
+    const warn = Sinon.stub(console, 'warn');
+
+    class Child extends ImpulseElement {}
+    class Parent extends ImpulseElement {
+      @target() child!: Child;
+    }
+    Parent.migratedToWhenInitialized = true;
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+      <${parentTag}>
+        <${childTag} data-target="${parentTag}.child"></${childTag}>
+      </${parentTag}>
+    `;
+
+    registerElement(parentTag)(Parent);
+    document.body.appendChild(wrapper);
+
+    try {
+      // Give `_asyncConnect` time to run past `_resolveUndefinedElements`.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(warn.called).to.be.false;
+    } finally {
+      warn.restore();
       wrapper.remove();
     }
   });

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
           { text: 'emit', link: '/utilities/emit' },
           { text: 'lazyImport', link: '/utilities/lazy-import' },
           { text: 'on', link: '/utilities/on' },
+          { text: 'whenInitialized', link: '/utilities/when-initialized' },
         ],
       },
       {

--- a/packages/docs/reference/lifecycle-callbacks.md
+++ b/packages/docs/reference/lifecycle-callbacks.md
@@ -42,6 +42,24 @@ buttonsConnected(button: HTMLButtonElement) {
 }
 ```
 
+::: warning Deprecated behavior
+When this callback fires, the target element is in the DOM but may not have finished initializing, so its `@property`
+accessors may not be installed yet. Today Impulse implicitly waits for descendant custom elements to be defined before
+invoking these callbacks, but **this implicit wait is deprecated and will be removed in the next major version.**
+
+If a connected callback reads properties on a target element, await
+[`whenInitialized`](/utilities/when-initialized) inside the callback instead:
+
+```ts
+async panelConnected(panel: PanelElement) {
+  await whenInitialized(panel);
+  console.log(panel.someProperty);
+}
+```
+
+Once you have migrated, silence the deprecation warning by setting `ImpulseElement.migratedToWhenInitialized = true`.
+:::
+
 ### `connected()`
 
 This function is called when the element itself is connected to the DOM. When this function is invoked, you can be sure

--- a/packages/docs/utilities/when-initialized.md
+++ b/packages/docs/utilities/when-initialized.md
@@ -1,0 +1,45 @@
+# whenInitialized
+
+The `whenInitialized` function returns a promise that resolves once an element has been fully initialized by Impulse —
+that is, once its properties, targets, and actions have started and the `data-impulse-element` marker attribute has been
+set.
+
+This mirrors the familiar [`customElements.whenDefined()`](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/whenDefined)
+pattern, but resolves on full initialization rather than mere definition.
+
+## Usage
+
+```ts
+import { whenInitialized } from '@ambiki/impulse';
+
+const select = await whenInitialized(this.selectTarget);
+select.doSomething();
+```
+
+- **Standard HTML elements** (a tag name without a hyphen can never be a custom element) resolve immediately — there is
+  nothing to initialize.
+- **Custom elements** resolve once the marker attribute is set. If that does not happen within `timeout` milliseconds the
+  promise rejects, so a mistyped or non-Impulse element surfaces an error instead of hanging forever.
+
+## Reading a target's properties from a connected callback
+
+When a `[target]Connected()` callback fires, the target element is in the DOM but may not have finished initializing yet,
+so its `@property` accessors may not be installed. If you need to read a target's properties, await `whenInitialized`
+first:
+
+```ts
+@target() select: SelectElement;
+
+async selectConnected(select: SelectElement) {
+  await whenInitialized(select);
+  console.log(select.value); // safe to read Impulse properties now
+}
+```
+
+## Timeout
+
+The default timeout is `3000` milliseconds. Pass a custom `timeout` to override it:
+
+```ts
+await whenInitialized(this.selectTarget, { timeout: 5000 });
+```


### PR DESCRIPTION
## Summary

`ImpulseElement._asyncConnect()` calls `await this._resolveUndefinedElements()`, which blocks (via `customElements.whenDefined`) until every undefined descendant custom element is defined — so a target's `@property` accessors exist by the time a parent's `[target]Connected()` callback reads them.

This implicit, timing-based behavior is observable to end users, so it can't be removed outright. This PR is the **deprecation step** (non-breaking, stays in v1); the actual removal of `_resolveUndefinedElements` is planned for the next major.

## What changes

- **`element.ts`** — the wait still works, but `_resolveUndefinedElements` now emits a `console.warn` whenever it engages (there's at least one undefined descendant), pointing users to `whenInitialized()`. A new static flag `ImpulseElement.migratedToWhenInitialized` (default `false`, read via `this.constructor` so it's inherited and overridable per element class) suppresses the warning once a user has migrated. Set it globally (`ImpulseElement.migratedToWhenInitialized = true`) or on a specific class.
- **Docs** — new `whenInitialized` utilities page + sidebar entry; a deprecation note on `[target]Connected()` showing the `await whenInitialized(target)` migration pattern; CHANGELOG `Deprecated` entry.
- **Tests** — assert the warning fires when a parent has an undefined custom-element target, and that setting `migratedToWhenInitialized = true` suppresses it.

## Migration

```ts
@target() select: SelectElement;

async selectConnected(select: SelectElement) {
  await whenInitialized(select);   // replaces the implicit wait
  console.log(select.value);
}
```
Then `ImpulseElement.migratedToWhenInitialized = true` to silence the warning.

## Test plan

- `yarn workspace @ambiki/impulse test` — **134/134 pass**. Verified red→green: neutralizing the `console.warn` makes the new deprecation test fail (`Timeout: deprecation warning should be emitted`), restoring it goes green.
- `yarn lint` — clean (antfu permits `console.warn`).
- `yarn workspace @ambiki/impulse build` — clean.
- `yarn docs:build` — builds with the new page and sidebar entry.

## Out of scope

- **Removing** the wait — that's the next-major change.
- Non-Impulse custom-element targets (`whenInitialized` would time out for them) — intentionally not addressed; targets are assumed to be Impulse elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)