### PR TITLE
feat(core): make whenInitialized work for non-Impulse custom elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `whenInitialized` to await an element being fully initialized. Standard elements resolve immediately; custom elements reject after a configurable timeout (default 3000ms) if they never initialize ([#111](https://github.com/Ambiki/impulse/issues/111))
+- Add `whenInitialized` to await an element being ready. Standard elements resolve immediately; Impulse elements resolve once fully initialized; non-Impulse custom elements resolve once defined (like `customElements.whenDefined`). Rejects after a configurable timeout (default 3000ms) if the element is never registered ([#111](https://github.com/Ambiki/impulse/issues/111))
 - Export `SetMap`
 - Export `SelectorSet` data structure for indexing CSS selectors by their leftmost token
 

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -1,5 +1,6 @@
 import type { Watcher } from './observers/document_observer';
 import { IMPULSE_ELEMENT_ATTRIBUTE } from './constants';
+import { ImpulseElement } from './element';
 import { watchSelector } from './observers/document_observer';
 
 /**
@@ -107,14 +108,16 @@ const DEFAULT_INITIALIZED_TIMEOUT = 3000;
  * Returns a promise that resolves once the element has been fully initialized by Impulse, i.e. once its properties,
  * targets, and actions have started and the `data-impulse-element` marker attribute has been set.
  *
- * This mirrors the familiar `customElements.whenDefined()` pattern, but resolves on full initialization rather than
- * mere definition.
+ * This mirrors the familiar `customElements.whenDefined()` pattern, but for an Impulse element resolves on full
+ * initialization rather than mere definition.
  *
  * - **Standard HTML elements** (a tag name without a hyphen can never be a custom element) resolve immediately —
  *   there is nothing to initialize.
- * - **Custom elements** resolve once the marker attribute is set. If that does not happen within `timeout`
- *   milliseconds the promise rejects, so a mistyped or non-Impulse element surfaces an error instead of hanging
- *   forever (and the underlying observer is always cleaned up).
+ * - **Impulse custom elements** resolve once the `data-impulse-element` marker attribute is set.
+ * - **Non-Impulse custom elements** never receive the marker, so they resolve as soon as their class is defined
+ *   (equivalent to `customElements.whenDefined`) — making this safe to use on any target element.
+ * - If none of the above happens within `timeout` milliseconds the promise rejects, so a mistyped or never-registered
+ *   element surfaces an error instead of hanging forever (and the underlying observer is always cleaned up).
  *
  * @param element - The element to wait for.
  * @param options - Optional settings.
@@ -141,14 +144,33 @@ export function whenInitialized<T extends Element>(
     return Promise.resolve(element);
   }
 
+  let settled = false;
   let stop: (() => void) | undefined;
   let timer: ReturnType<typeof setTimeout>;
 
-  // `connected` fires when an element starts matching the selector, including when the marker attribute is added
-  // later by `_asyncConnect`. We filter to our specific element.
+  // Wait for the class to be registered, then decide how "initialized" is defined for this element.
   const initialized = new Promise<T>((resolve) => {
-    stop = connected<T>(`[${IMPULSE_ELEMENT_ATTRIBUTE}]`, (el) => {
-      if (el === element) resolve(element);
+    customElements.whenDefined(element.localName).then(() => {
+      // The race may have already settled (e.g. timed out) before the class was defined.
+      if (settled) return;
+
+      // Non-Impulse custom elements never get the marker; being defined is as ready as they get.
+      if (!isImpulseElement(element.localName)) {
+        resolve(element);
+        return;
+      }
+
+      // The Impulse element may have finished initializing while we waited for the definition.
+      if (element.hasAttribute(IMPULSE_ELEMENT_ATTRIBUTE)) {
+        resolve(element);
+        return;
+      }
+
+      // `connected` fires when an element starts matching the selector, including when the marker attribute is added
+      // later by `_asyncConnect`. We filter to our specific element.
+      stop = connected<T>(`[${IMPULSE_ELEMENT_ATTRIBUTE}]`, (el) => {
+        if (el === element) resolve(element);
+      });
     });
   });
 
@@ -159,9 +181,20 @@ export function whenInitialized<T extends Element>(
   });
 
   // Whichever settles first wins; `finally` clears the timer and stops the shared-observer watcher on both the
-  // resolve and reject paths so nothing leaks.
+  // resolve and reject paths so nothing leaks. `settled` guards against a late `whenDefined` callback registering a
+  // watcher after the race has already finished.
   return Promise.race([initialized, timedOut]).finally(() => {
+    settled = true;
     clearTimeout(timer);
     stop?.();
   });
+}
+
+/**
+ * Whether the custom element registered for `localName` is an `ImpulseElement` (or a subclass). Returns `false` when the
+ * tag is unregistered or registered to a non-Impulse class.
+ */
+function isImpulseElement(localName: string): boolean {
+  const ctor = customElements.get(localName);
+  return !!ctor && (ctor === ImpulseElement || ctor.prototype instanceof ImpulseElement);
 }

--- a/packages/core/test/lifecycle.test.ts
+++ b/packages/core/test/lifecycle.test.ts
@@ -266,6 +266,43 @@ describe('whenInitialized', () => {
     expect(resolved).to.eq(element);
   });
 
+  it('resolves once a non-Impulse custom element is defined', async () => {
+    counter += 1;
+    const tag = `non-impulse-${counter}`;
+    // A plain custom element that is not an ImpulseElement, so it never receives the marker attribute.
+    class Plain extends HTMLElement {}
+    customElements.define(tag, Plain);
+
+    const element = document.createElement(tag);
+    document.body.appendChild(element);
+
+    try {
+      const resolved = await whenInitialized(element, { timeout: CONNECTION_TIMEOUT_MS });
+      expect(resolved).to.eq(element);
+      expect(element.hasAttribute('data-impulse-element')).to.be.false;
+    } finally {
+      element.remove();
+    }
+  });
+
+  it('resolves once a non-Impulse custom element is defined after the call', async () => {
+    counter += 1;
+    const tag = `non-impulse-late-${counter}`;
+    class Plain extends HTMLElement {}
+
+    const element = document.createElement(tag);
+    document.body.appendChild(element);
+
+    try {
+      const promise = whenInitialized(element, { timeout: CONNECTION_TIMEOUT_MS });
+      customElements.define(tag, Plain);
+      const resolved = await promise;
+      expect(resolved).to.eq(element);
+    } finally {
+      element.remove();
+    }
+  });
+
   it('rejects when a custom element is not initialized within the timeout', async () => {
     counter += 1;
     // A hyphenated tag that is never registered, so it never initializes.

--- a/packages/docs/utilities/when-initialized.md
+++ b/packages/docs/utilities/when-initialized.md
@@ -1,11 +1,11 @@
 # whenInitialized
 
-The `whenInitialized` function returns a promise that resolves once an element has been fully initialized by Impulse —
-that is, once its properties, targets, and actions have started and the `data-impulse-element` marker attribute has been
-set.
+The `whenInitialized` function returns a promise that resolves once an element is ready to be interacted with. For an
+Impulse element that means once its properties, targets, and actions have started and the `data-impulse-element` marker
+attribute has been set.
 
 This mirrors the familiar [`customElements.whenDefined()`](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/whenDefined)
-pattern, but resolves on full initialization rather than mere definition.
+pattern, but for an Impulse element resolves on full initialization rather than mere definition.
 
 ## Usage
 
@@ -18,8 +18,12 @@ select.doSomething();
 
 - **Standard HTML elements** (a tag name without a hyphen can never be a custom element) resolve immediately — there is
   nothing to initialize.
-- **Custom elements** resolve once the marker attribute is set. If that does not happen within `timeout` milliseconds the
-  promise rejects, so a mistyped or non-Impulse element surfaces an error instead of hanging forever.
+- **Impulse custom elements** resolve once the marker attribute is set.
+- **Non-Impulse custom elements** never receive the marker, so they resolve as soon as their class is defined
+  (equivalent to `customElements.whenDefined`). This makes `whenInitialized` safe to use on any target element,
+  whether or not it is an Impulse element.
+- If none of the above happens within `timeout` milliseconds the promise rejects, so a mistyped or never-registered
+  element surfaces an error instead of hanging forever.
 
 ## Reading a target's properties from a connected callback
 


### PR DESCRIPTION
## Summary

`whenInitialized` waited for the `data-impulse-element` marker for any hyphenated tag. A **non-Impulse** custom-element target never receives that marker, so `whenInitialized` would always **reject after the timeout** for it — making the helper unsafe to use on arbitrary targets.

This teaches `whenInitialized` to distinguish the two:

1. Already has the marker, or not a custom element (no hyphen) → resolve immediately (unchanged).
2. Otherwise wait for `customElements.whenDefined(localName)`, then:
   - **Impulse element** (registered class is `ImpulseElement` or a subclass) → wait for the marker, as before.
   - **Non-Impulse custom element** → "defined" is as ready as it gets, so resolve (equivalent to `customElements.whenDefined`).
3. The `timeout` still rejects genuinely never-registered / mistyped tags.

Detection uses the registered constructor (`customElements.get(localName)`), not the instance, so it works regardless of upgrade state. A `settled` flag prevents a late `whenDefined` callback from registering a leaked observer if the race already timed out.

No import cycle: `element.ts` does not import `lifecycle.ts`.

## Behavior change

`whenInitialized` no longer rejects for a *defined* non-Impulse custom element — it resolves. It still rejects for a tag that is never registered. `whenInitialized` is still unreleased (Unreleased in the CHANGELOG), so this refines that pending entry rather than changing shipped behavior.

## Test plan

- `yarn workspace @ambiki/impulse test` — **136/136 pass**. Added two tests (non-Impulse element defined before, and after, the call). Verified red→green: forcing `isImpulseElement` to always return `true` makes exactly those two tests fail (timeout); restoring it goes green. The existing "rejects … not initialized within the timeout" test (never-registered tag) still passes.
- `yarn lint`, `yarn workspace @ambiki/impulse build`, `yarn docs:build` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)