### PR TITLE
feat(core): drop whenInitialized default timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `whenInitialized` to await an element being ready. Standard elements resolve immediately; Impulse elements resolve once fully initialized; non-Impulse custom elements resolve once defined (like `customElements.whenDefined`). Rejects after a configurable timeout (default 3000ms) if the element is never registered ([#111](https://github.com/Ambiki/impulse/issues/111))
+- Add `whenInitialized` to await an element being ready. Standard elements resolve immediately; Impulse elements resolve once fully initialized; non-Impulse custom elements resolve once defined (like `customElements.whenDefined`). By default there is no deadline (it waits indefinitely, like `customElements.whenDefined`); pass `{ timeout }` to reject after a number of milliseconds you choose ([#111](https://github.com/Ambiki/impulse/issues/111))
 - Export `SetMap`
 - Export `SelectorSet` data structure for indexing CSS selectors by their leftmost token
 

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -102,11 +102,9 @@ export function disconnected<T extends Element = Element>(selector: string, call
   return watchSelector<T>(selector, { elementDisconnected: callback });
 }
 
-const DEFAULT_INITIALIZED_TIMEOUT = 3000;
-
 /**
- * Returns a promise that resolves once the element has been fully initialized by Impulse, i.e. once its properties,
- * targets, and actions have started and the `data-impulse-element` marker attribute has been set.
+ * Returns a promise that resolves once the element is ready to be interacted with. For an Impulse element that means
+ * once its properties, targets, and actions have started and the `data-impulse-element` marker attribute has been set.
  *
  * This mirrors the familiar `customElements.whenDefined()` pattern, but for an Impulse element resolves on full
  * initialization rather than mere definition.
@@ -116,23 +114,29 @@ const DEFAULT_INITIALIZED_TIMEOUT = 3000;
  * - **Impulse custom elements** resolve once the `data-impulse-element` marker attribute is set.
  * - **Non-Impulse custom elements** never receive the marker, so they resolve as soon as their class is defined
  *   (equivalent to `customElements.whenDefined`) — making this safe to use on any target element.
- * - If none of the above happens within `timeout` milliseconds the promise rejects, so a mistyped or never-registered
- *   element surfaces an error instead of hanging forever (and the underlying observer is always cleaned up).
+ *
+ * By default there is no deadline: like `customElements.whenDefined`, the promise stays pending until the element is
+ * ready, so a never-registered (e.g. mistyped) tag never resolves and surfaces as code after the `await` that never
+ * runs. Pass `timeout` to reject after a number of milliseconds you choose — an acceptable wait depends on your bundle
+ * size and your users' network, which only the application can know, so the library does not guess one for you.
  *
  * @param element - The element to wait for.
  * @param options - Optional settings.
- * @param options.timeout - Milliseconds to wait for a custom element to initialize before rejecting. Defaults to 3000.
- * @returns A promise that resolves with the same element once it is initialized.
+ * @param options.timeout - Milliseconds to wait before rejecting. Omit (or pass `Infinity`) to wait indefinitely.
+ * @returns A promise that resolves with the same element once it is ready.
  *
  * @example
  * ```ts
  * const select = await whenInitialized(this.selectTarget);
  * select.doSomething();
+ *
+ * // Bail out after a deadline you choose:
+ * const panel = await whenInitialized(this.panelTarget, { timeout: 5000 });
  * ```
  */
 export function whenInitialized<T extends Element>(
   element: T,
-  { timeout = DEFAULT_INITIALIZED_TIMEOUT }: { timeout?: number } = {},
+  { timeout }: { timeout?: number } = {},
 ): Promise<T> {
   // Already initialized.
   if (element.hasAttribute(IMPULSE_ELEMENT_ATTRIBUTE)) {
@@ -146,7 +150,6 @@ export function whenInitialized<T extends Element>(
 
   let settled = false;
   let stop: (() => void) | undefined;
-  let timer: ReturnType<typeof setTimeout>;
 
   // Wait for the class to be registered, then decide how "initialized" is defined for this element.
   const initialized = new Promise<T>((resolve) => {
@@ -174,6 +177,16 @@ export function whenInitialized<T extends Element>(
     });
   });
 
+  // No deadline by default: wait until the element is ready, mirroring `customElements.whenDefined`. A never-defined tag
+  // simply parks on the native `whenDefined` promise (no per-element watcher is created until the class is defined).
+  if (timeout === undefined || !Number.isFinite(timeout)) {
+    return initialized.finally(() => {
+      settled = true;
+      stop?.();
+    });
+  }
+
+  let timer: ReturnType<typeof setTimeout>;
   const timedOut = new Promise<never>((_resolve, reject) => {
     timer = setTimeout(() => {
       reject(new Error(`<${element.localName}> was not initialized within ${timeout}ms.`));

--- a/packages/core/test/lifecycle.test.ts
+++ b/packages/core/test/lifecycle.test.ts
@@ -303,7 +303,34 @@ describe('whenInitialized', () => {
     }
   });
 
-  it('rejects when a custom element is not initialized within the timeout', async () => {
+  it('waits indefinitely by default and resolves once the element initializes', async () => {
+    counter += 1;
+    const tag = `no-timeout-${counter}`;
+    class Element extends ImpulseElement {}
+
+    const element = document.createElement(tag) as Element;
+    document.body.appendChild(element);
+
+    try {
+      const promise = whenInitialized(element);
+
+      // With no deadline the promise stays pending while the tag is unregistered - it does not reject.
+      const outcome = await Promise.race([
+        promise.then(() => 'settled', () => 'settled'),
+        new Promise((resolve) => setTimeout(resolve, 50, 'pending')),
+      ]);
+      expect(outcome).to.eq('pending');
+
+      // Once the class is registered it resolves.
+      registerElement(tag)(Element);
+      const resolved = await promise;
+      expect(resolved).to.eq(element);
+    } finally {
+      element.remove();
+    }
+  });
+
+  it('rejects after an explicit timeout when the element never initializes', async () => {
     counter += 1;
     // A hyphenated tag that is never registered, so it never initializes.
     const tag = `never-impulse-${counter}`;

--- a/packages/docs/utilities/when-initialized.md
+++ b/packages/docs/utilities/when-initialized.md
@@ -22,8 +22,6 @@ select.doSomething();
 - **Non-Impulse custom elements** never receive the marker, so they resolve as soon as their class is defined
   (equivalent to `customElements.whenDefined`). This makes `whenInitialized` safe to use on any target element,
   whether or not it is an Impulse element.
-- If none of the above happens within `timeout` milliseconds the promise rejects, so a mistyped or never-registered
-  element surfaces an error instead of hanging forever.
 
 ## Reading a target's properties from a connected callback
 
@@ -42,8 +40,23 @@ async selectConnected(select: SelectElement) {
 
 ## Timeout
 
-The default timeout is `3000` milliseconds. Pass a custom `timeout` to override it:
+By default there is **no deadline** — like `customElements.whenDefined`, the promise stays pending until the element is
+ready. A never-registered (e.g. mistyped) tag therefore never resolves, which surfaces as the code after your `await`
+never running.
+
+If you want to bail out after a while, pass a `timeout` (in milliseconds) and the promise rejects once it elapses. An
+acceptable wait depends on your bundle size and your users' network — which only your application knows — so the library
+does not pick one for you:
 
 ```ts
-await whenInitialized(this.selectTarget, { timeout: 5000 });
+try {
+  const panel = await whenInitialized(this.panelTarget, { timeout: 5000 });
+} catch {
+  // The element did not become ready in time.
+}
 ```
+
+::: tip
+When awaiting a [lazily imported](/utilities/lazy-import) element, remember the wait includes fetching and executing its
+JavaScript chunk. If you set a `timeout`, size it for your worst-case network, or omit it to wait indefinitely.
+:::


### PR DESCRIPTION
## Summary

A fixed timeout is the library guessing an acceptable wait on the application's behalf — but acceptable latency depends on bundle size and the end user's network, which only the application knows. The old `3000ms` default caused spurious rejections for legitimately slow cases (most visibly: a [lazily imported](https://ambiki.github.io/impulse/utilities/lazy-import) element whose JS chunk takes >3s to fetch would reject even though it loads fine moments later).

So `whenInitialized` no longer imposes a deadline by default:

- **Default (no `timeout`)** — stays pending until the element is ready, exactly like `customElements.whenDefined`. A never-registered (e.g. mistyped) tag never resolves, surfacing as code after the `await` that never runs — the same dev-time failure mode `whenDefined` already has.
- **Opt-in `timeout`** — pass a number of milliseconds *you* choose to reject after a deadline. `Infinity` or omitting it waits indefinitely.

```ts
await whenInitialized(this.selectTarget);                 // no deadline (like whenDefined)
await whenInitialized(this.panelTarget, { timeout: 5000 }); // caller-chosen deadline
```

No leak from waiting forever: a never-defined tag just parks on the native `customElements.whenDefined` promise; the per-element marker watcher is only created once the class is defined (initialization imminent).

## Behavior change

The previous default rejected after 3000ms; it now waits indefinitely unless a `timeout` is passed. `whenInitialized` is still under `[Unreleased]` in the CHANGELOG, so this only refines pending (unshipped) behavior.

## Test plan

- `yarn workspace @ambiki/impulse test` — **137/137 pass**. Replaced the old "rejects after timeout (default)" test with: "waits indefinitely by default and resolves once the element initializes" + "rejects after an explicit timeout when the element never initializes". Verified red→green: reintroducing a finite default makes the indefinite-wait test fail; removing it goes green.
- `yarn lint`, `yarn workspace @ambiki/impulse build`, `yarn docs:build` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)