### PR TITLE
fix(core): start properties synchronously on connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Define `@property` accessors synchronously when an element connects, instead of after `await domReady()`. A defined element's properties are now live as soon as it connects, closing a race where a parent's `[target]Connected(child)` callback could read a property on an already-defined child before the child's accessors existed ([#124](https://github.com/Ambiki/impulse/pull/124))
 - Preserve DOM order for `@targets()` when a target is dynamically inserted between existing targets
 - Remove the `data-impulse-element` attribute when an element is disconnected so mutation observers tracking it stay in sync with the DOM connection state ([#110](https://github.com/Ambiki/impulse/issues/110))
 

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -99,10 +99,13 @@ export class ImpulseElement extends HTMLElement {
   }
 
   private async _asyncConnect() {
+    // Define property accessors synchronously, before yielding to `domReady`, so a defined element's properties are live
+    // as soon as it connects. Property setup only reads the element's own attributes/defaults, so it does not need to
+    // wait for the document or for descendants (unlike `target`/`action`, which scan children).
+    this.property.start();
     await domReady();
     customElements.upgrade(this);
     // Order is important
-    this.property.start();
     // Resolve all undefined elements before initializing the target/targets so that property references can be resolved
     // to the assigned value.
     // DEPRECATED: this implicit wait will be removed in the next major version. Use `whenInitialized()` inside connected

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -105,12 +105,12 @@ export class ImpulseElement extends HTMLElement {
     this.property.start();
     await domReady();
     customElements.upgrade(this);
-    // Order is important
     // Resolve all undefined elements before initializing the target/targets so that property references can be resolved
     // to the assigned value.
     // DEPRECATED: this implicit wait will be removed in the next major version. Use `whenInitialized()` inside connected
     // callbacks instead. See `_resolveUndefinedElements`.
     await this._resolveUndefinedElements();
+    // Order is important: targets must be wired up before actions.
     this.target.start();
     this.action.start();
     this._started = true;

--- a/packages/core/test/element.test.ts
+++ b/packages/core/test/element.test.ts
@@ -111,6 +111,74 @@ describe('ImpulseElement connection order', () => {
     }
   });
 
+  it('makes @property accessors live synchronously on connect, before yielding to domReady', () => {
+    counter += 1;
+    const tag = `sync-property-${counter}`;
+
+    class Element extends ImpulseElement {
+      @property({ type: String }) message = 'default';
+    }
+
+    registerElement(tag)(Element);
+
+    const element = document.createElement(tag) as Element & { message: string };
+    element.setAttribute('message', 'from-attribute');
+    document.body.appendChild(element);
+
+    try {
+      // `connectedCallback` runs synchronously inside `appendChild` (a [CEReactions] operation), and
+      // `property.start()` is the first statement of `_asyncConnect`, before `await domReady()`. So the
+      // attribute-backed getter must already be live here, with no `await`. This guards against a future
+      // refactor moving `property.start()` back below the await, where this would read the raw field
+      // default (`'default'`) because the accessor would not yet be defined.
+      expect(element.message).to.eq('from-attribute');
+    } finally {
+      element.remove();
+    }
+  });
+
+  it('reads a defined target child’s @property inside the connected callback', async () => {
+    counter += 1;
+    const parentTag = `defined-parent-${counter}`;
+    const childTag = `defined-child-${counter}`;
+
+    class Child extends ImpulseElement {
+      @property({ type: String }) message = 'default';
+    }
+
+    class Parent extends ImpulseElement {
+      @target() child!: Child;
+      capturedMessage = '<unset>';
+      childConnected(child: Child) {
+        this.capturedMessage = child.message;
+      }
+    }
+
+    // Both classes are registered up front, so the child is already defined at parse time and the
+    // implicit `_resolveUndefinedElements` wait does not engage. The parent must still observe the
+    // child's attribute-backed property because the child's accessors are defined synchronously on connect.
+    registerElement(childTag)(Child);
+    registerElement(parentTag)(Parent);
+
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+      <${parentTag}>
+        <${childTag} message="from-attribute" data-target="${parentTag}.child"></${childTag}>
+      </${parentTag}>
+    `;
+    document.body.appendChild(wrapper);
+
+    try {
+      const parent = wrapper.firstElementChild as Parent;
+      await waitUntil(() => parent.capturedMessage !== '<unset>', 'childConnected should fire', {
+        timeout: CONNECTION_TIMEOUT_MS,
+      });
+      expect(parent.capturedMessage).to.eq('from-attribute');
+    } finally {
+      wrapper.remove();
+    }
+  });
+
   it('adds the data-impulse-element attribute on connect and removes it on disconnect', async () => {
     counter += 1;
     const tag = `marker-element-${counter}`;


### PR DESCRIPTION
## What

Move `this.property.start()` to be the **first statement** of `_asyncConnect()`, before `await domReady()`.

```ts
private async _asyncConnect() {
  this.property.start();        // now synchronous, during connectedCallback
  await domReady();
  customElements.upgrade(this);
  await this._resolveUndefinedElements();
  this.target.start();
  this.action.start();
  ...
}
```

Because `_asyncConnect` is an async function, statements before its first `await` execute synchronously within `connectedCallback`. So a defined element's `@property` accessors are now live the moment it connects, instead of one microtask after `domReady()` resolves.

## Why

For a parent A connected before child B (parser order), A's post-`domReady` continuation runs before B's, so `A.targetConnected(B)` could fire **before** `B.property.start()` — B's accessors weren't live yet. Property setup only reads the element's *own* attributes/defaults; it does not need `domReady()` (unlike `target`/`action`, which scan descendants). Running it synchronously on connect closes this "defined-but-not-initialized" window.

This came out of a discussion on whether `property.ts` could be folded into the `@property` decorator to improve init timing. It can't — the decorator runs once at class-definition time with only the prototype, while `start()` does per-instance work (read the class-field default, and only reflect it to the attribute when the author didn't already set one). With `useDefineForClassFields: false`, a prototype setter would also clobber an author-provided `<el count="10">`. The real lever is *where* `start()` runs, which is what this PR changes.

## Scope

Complementary to #123 — this does **not** remove `_resolveUndefinedElements`, the deprecation warning, or `whenInitialized()`, which still cover the *undefined* (unregistered) descendant case.

## Verification

- `yarn test` — all 15 files / 137 tests pass.
- `yarn lint` — clean.
- `Property` itself is unchanged: the `if (!hasAttribute) set(default)` guard still runs per instance, so attribute-beats-default precedence is preserved; `attributeChangedCallback` stays gated on `_started`, so default reflection during early `property.start()` won't fire `xChanged` during init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)