### PR TITLE
feat(docs): add favicon and nav bar logo

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -5,9 +5,11 @@ export default defineConfig({
   base: '/impulse/',
   title: 'Impulse',
   description: 'A JavaScript framework that leverages the Web Components API.',
+  head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/impulse/favicon.svg' }]],
   lastUpdated: true,
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
+    logo: '/favicon.svg',
     nav: [{ text: 'Home', link: '/' }],
     outline: 'deep',
     search: {

--- a/packages/docs/public/favicon.svg
+++ b/packages/docs/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="7" fill="#3451b2"/>
+  <path d="M17.5 5 9 18h6l-1.5 9L23 13h-6l.5-8z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary

The docs site had no favicon configured, so every browser's automatic `GET /favicon.ico` request 404'd. This adds an Impulse SVG icon and wires it up.

- Add `packages/docs/public/favicon.svg` (a simple lightning-bolt mark; VitePress serves `public/` at the site root)
- Reference it as the favicon via a `head` link (uses the explicit `/impulse/` base, since VitePress doesn't auto-prepend `base` to `head` tags)
- Use the same icon as the nav bar logo via `themeConfig.logo` (base auto-applied)

## Notes

- The favicon is a placeholder vector mark — easy to swap for a real `.ico` or refined design later without touching the wiring.
- No homepage hero image (considered, then dropped to keep the hero simple).

🤖 Generated with [Claude Code](https://claude.com/claude-code)